### PR TITLE
fixing a typo

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,6 +8,6 @@ infra:
 
 services:
   webapp:
-    project: ./Website
+    project: ./WebSite
     host: appservice
     language: dotnet


### PR DESCRIPTION
The directory is named WebSite (with a capital "S") while the Azure deployment azd up is looking for Website (with a lowercase "s").